### PR TITLE
Issue 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             #docker-compose exec centos7 yum -y install grub2
             #docker-compose exec centos7 grub2-install /dev/sda
             #docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
-            docker-compose exec centos7 grub2-mkconfig
+            docker-compose exec centos7 /usr/sbin/grub2-mkconfig
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Run playbook.yml in remote Docker container
           command: |
-            docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
+            #docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       #FIXME Uncomment once tasks are all idempotent
       #FIXME Uncomment once tasks are all idempotent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
             #docker-compose exec centos7 yum -y install grub2
-            docker-compose exec centos7 grub2-install /dev/sda
+            #docker-compose exec centos7 grub2-install /dev/sda
             #docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
-            #docker-compose exec centos7 grub2-mkconfig -o /boot/grub2/grub.cfg
+            docker-compose exec centos7 grub2-mkconfig
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
             docker-compose exec centos7 yum -y install grub2
+            docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
+            docker-compose exec centos7 grub2-mkconfig -o /boot/grub2/grub.cfg
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,12 +32,6 @@ jobs:
             docker-compose exec centos7 yum -y install cronie
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
-            docker-compose exec centos7 yum -y install grub2-efi shim
-            #docker-compose exec centos7 grub2-install /dev/sda
-            #docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
-            docker-compose exec centos7 /usr/sbin/grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
-            #docker-compose exec centos7 /usr/sbin/grub-install /dev/sda
-            #docker-compose exec centos7 /usr/sbin/grub2-mkconfig
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             docker-compose exec centos7 yum -y install cronie
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
-            docker-compose exec centos7 yum -y install grub2
+            docker-compose exec centos7 yum -y install grub2-efi shim
             #docker-compose exec centos7 grub2-install /dev/sda
             #docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
             docker-compose exec centos7 /usr/sbin/update-grub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             docker-compose exec centos7 yum -y install cronie
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
-            docker-compose exec centos7 yum -y grub-efi
+            docker-compose exec centos7 yum -y grub2-efi
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Run playbook.yml in remote Docker container
           command: |
-            docker-compose exec -T centos7 mkdir -r /etc/ansible/roles
+            docker-compose exec -T centos7 mkdir -p /etc/ansible/roles
             docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             docker-compose exec centos7 yum -y install cronie
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
-            #docker-compose exec centos7 yum -y install grub2
+            docker-compose exec centos7 yum -y install grub2
             #docker-compose exec centos7 grub2-install /dev/sda
             #docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
             docker-compose exec centos7 /usr/sbin/grub2-mkconfig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             docker-compose exec centos7 yum -y install cronie
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
-            docker-compose exec centos7 yum -y reinstall grub2-efi shim
+            docker-compose exec centos7 yum -y install grub2
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,7 @@ jobs:
             docker-compose exec -T centos7 mkdir -p /etc/ansible/roles
             docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
-            docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       - run:
           name: Run playbook.yml again, checking to make sure it's idempotent
           command: >
-            docker-compose exec -T centos7 ansible-playbook --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml | grep 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)
+            docker-compose exec -T centos7 ansible-playbook --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml | grep 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,12 @@ jobs:
           command: |
             docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
+      - run:
+          name: Run playbook.yml in remote Docker container
+          command: |
+            docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
+            docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
+      #FIXME Uncomment once tasks are all idempotent
       #FIXME Uncomment once tasks are all idempotent
       #- run:
        #   name: Run playbook.yml again, checking to make sure it's idempotent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ jobs:
       - run:
           name: Install Ansible in remote container
           command: |
-            docker-compose exec centos7 easy_install pip
+            docker-compose exec centos7 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+            docker-compose exec centos7 python get-pip.py
             docker-compose exec centos7 pip install ansible
       - run:
           name: Copy Ansible Code to Remote Container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,9 @@ jobs:
             docker-compose exec centos7 yum -y install grub2
             #docker-compose exec centos7 grub2-install /dev/sda
             #docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
-            docker-compose exec centos7 /usr/sbin/grub2-mkconfig
+            docker-compose exec centos7 /usr/sbin/update-grub
+            docker-compose exec centos7 /usr/sbin/grub-install /dev/sda
+            #docker-compose exec centos7 /usr/sbin/grub2-mkconfig
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: Run playbook.yml in remote Docker container
           command: |
-            docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
+            #docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       - run:
           name: Run playbook.yml in remote Docker container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
             docker-compose exec -T centos7 mkdir -p /etc/ansible/roles
             docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
+            docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       - run:
           name: Run playbook.yml again, checking to make sure it's idempotent
           command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
             docker-compose exec centos7 yum -y install grub2-efi shim
             #docker-compose exec centos7 grub2-install /dev/sda
             #docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
-            docker-compose exec centos7 /usr/sbin/update-grub
-            docker-compose exec centos7 /usr/sbin/grub-install /dev/sda
+            docker-compose exec centos7 /usr/sbin/grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg
+            #docker-compose exec centos7 /usr/sbin/grub-install /dev/sda
             #docker-compose exec centos7 /usr/sbin/grub2-mkconfig
       - run:
           name: Run playbook.yml in remote Docker container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,13 @@ jobs:
       - run:
           name: Run playbook.yml in remote Docker container
           command: |
-            docker-compose exec -T centos7 cp -r /home/circleci/project/* /usr/share/ansible/roles
+            docker-compose exec -T centos7 mkdir -r /etc/ansible/roles
+            docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       - run:
           name: Run playbook.yml in remote Docker container
           command: |
-            docker-compose exec -T centos7 cp -r /home/circleci/project/* /usr/share/ansible/roles
+            docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       #FIXME Uncomment once tasks are all idempotent
       #FIXME Uncomment once tasks are all idempotent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,10 @@ jobs:
             docker-compose exec centos7 systemctl start crond.service
             docker-compose exec centos7 yum -y install rsyslog
       - run:
+          name: Temp Test Step
+          command: |
+           docker-compose exec centos7 cat /etc/audit/auditd.conf
+      - run:
           name: Run playbook.yml in remote Docker container
           command: |
             docker-compose exec -T centos7 mkdir -p /etc/ansible/roles
@@ -46,6 +50,10 @@ jobs:
           command: |
             docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
+      - run:
+          name: Temp Test Step
+          command: |
+           docker-compose exec centos7 cat /etc/audit/auditd.conf
       #FIXME Uncomment once tasks are all idempotent
       #FIXME Uncomment once tasks are all idempotent
       #- run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             docker-compose exec centos7 yum -y install cronie
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
+            docker-compose exec centos7 yum -y install rsyslog
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ jobs:
       - run:
           name: Install Ansible in remote container
           command: |
-            docker-compose exec centos7 yum -y install ansible
+            docker-compose exec centos7 easy_install pip
+            docker-compose exec centos7 pip install ansible
       - run:
           name: Copy Ansible Code to Remote Container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             docker-compose exec centos7 yum -y install cronie
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
-            docker-compose exec centos7 yum -y grub2-efi
+            docker-compose exec centos7 yum -y reinstall grub2-efi shim
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Run playbook.yml in remote Docker container
           command: |
             docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
-            docker-compose exec -T centos7 ansible-playbook -vv --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
+            docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       #FIXME Uncomment once tasks are all idempotent
       #- run:
        #   name: Run playbook.yml again, checking to make sure it's idempotent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             docker-compose exec centos7 yum -y install cronie
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
+            docker-compose exec centos7 yum -y grub-efi
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
             docker-compose exec centos7 yum -y install grub2
-            docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
+            #docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
             docker-compose exec centos7 grub2-mkconfig -o /boot/grub2/grub.cfg
       - run:
           name: Run playbook.yml in remote Docker container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,17 +42,6 @@ jobs:
             docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       - run:
-          name: Run playbook.yml in remote Docker container
-          command: |
-            docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
-            docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
-      - run:
-          name: Temp Test Step
-          command: |
-           docker-compose exec centos7 cat /etc/audit/auditd.conf
-      #FIXME Uncomment once tasks are all idempotent
-      #FIXME Uncomment once tasks are all idempotent
-      #- run:
-       #   name: Run playbook.yml again, checking to make sure it's idempotent
-        #  command: >
-         #   docker-compose exec -T centos7 ansible-playbook --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml | grep 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)
+          name: Run playbook.yml again, checking to make sure it's idempotent
+          command: >
+            docker-compose exec -T centos7 ansible-playbook --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml | grep 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,12 @@ jobs:
       - run:
           name: Run playbook.yml in remote Docker container
           command: |
-            #docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
+            docker-compose exec -T centos7 cp -r /home/circleci/project/* /usr/share/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       - run:
           name: Run playbook.yml in remote Docker container
           command: |
-            #docker-compose exec -T centos7 cp -r /home/circleci/project/* /etc/ansible/roles
+            docker-compose exec -T centos7 cp -r /home/circleci/project/* /usr/share/ansible/roles
             docker-compose exec -T centos7 ansible-playbook -vv --skip-tags no_test --connection=local --inventory 127.0.0.1, /home/circleci/project/ansible-os-rhel-7/playbook.yml
       #FIXME Uncomment once tasks are all idempotent
       #FIXME Uncomment once tasks are all idempotent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,10 @@ jobs:
             docker-compose exec centos7 yum -y install cronie
             docker-compose exec centos7 systemctl enable crond.service
             docker-compose exec centos7 systemctl start crond.service
-            docker-compose exec centos7 yum -y install grub2
+            #docker-compose exec centos7 yum -y install grub2
+            docker-compose exec centos7 grub2-install /dev/sda
             #docker-compose exec centos7 grub2-install --grub-setup=/bin/true /dev/sda
-            docker-compose exec centos7 grub2-mkconfig -o /boot/grub2/grub.cfg
+            #docker-compose exec centos7 grub2-mkconfig -o /boot/grub2/grub.cfg
       - run:
           name: Run playbook.yml in remote Docker container
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,6 @@ jobs:
             docker-compose exec centos7 systemctl start crond.service
             docker-compose exec centos7 yum -y install rsyslog
       - run:
-          name: Temp Test Step
-          command: |
-           docker-compose exec centos7 cat /etc/audit/auditd.conf
-      - run:
           name: Run playbook.yml in remote Docker container
           command: |
             docker-compose exec -T centos7 mkdir -p /etc/ansible/roles

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-RHEL 7 GSA Benchmark
+RHEL 7 GSA Benchmark [![CircleCI](https://circleci.com/gh/GSA/ansible-os-rhel-7.svg?style=shield)](https://circleci.com/gh/GSA/ansible-os-rhel-7)
 ====================
 
 This ansible content will configure RHEL/Centos 7 machine to be GSA compliant.
@@ -37,7 +37,7 @@ Note, a subset of controls were removed due to operational impact or organizatio
 Dependencies
 ------------
 
-Ansible > 2.4
+Ansible >= 2.7
 
 Example Playbook
 -------------------------

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -199,7 +199,6 @@
       state: present
       reload: yes
       sysctl_set: yes
-      #FIXME do we still need? ignoreerrors: yes
   tags:
       - sysctl
       - id_1.5.1
@@ -211,7 +210,6 @@
       state: present
       reload: yes
       sysctl_set: yes
-      #FIXME do we still need? ignoreerrors: yes
   tags:
       - id_1.5.3
 

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -4,7 +4,6 @@
       value: 0
       state: present
       reload: yes
-      #FIXME do we still need? ignoreerrors: yes
   when: rhel7gsa_is_router == false
   tags:
 
@@ -17,7 +16,6 @@
       sysctl_set: yes
       state: present
       reload: yes
-      #FIXME do we still need? ignoreerrors: yes
   with_items:
       - { name: net.ipv4.conf.all.send_redirects, value: 0 }
       - { name: net.ipv4.conf.default.send_redirects, value: 0 }
@@ -47,7 +45,6 @@
       sysctl_set: yes
       state: present
       reload: yes
-      #FIXME do we still need? ignoreerrors: yes
   with_items:
       - { name: net.ipv4.conf.all.accept_redirects, value: 0 }
       - { name: net.ipv4.conf.default.accept_redirects, value: 0 }
@@ -62,7 +59,6 @@
       sysctl_set: yes
       state: present
       reload: yes
-      #FIXME do we still need? ignoreerrors: yes
   with_items:
       - { name: net.ipv4.conf.all.secure_redirects, value: 0 }
       - { name: net.ipv4.conf.default.secure_redirects, value: 0 }
@@ -76,7 +72,6 @@
       sysctl_set: yes
       state: present
       reload: yes
-      #FIXME do we still need? ignoreerrors: yes
   with_items:
       - { name: net.ipv4.conf.all.log_martians, value: 1 }
       - { name: net.ipv4.conf.default.log_martians, value: 1 }
@@ -89,7 +84,6 @@
       value: 1
       state: present
       reload: yes
-      #FIXME do we still need? ignoreerrors: yes
   tags:
       - id_3.2.5
 
@@ -99,7 +93,6 @@
       value: 1
       state: present
       reload: yes
-      #FIXME do we still need? ignoreerrors: yes
   tags:
       - id_3.2.6
 
@@ -110,13 +103,11 @@
       sysctl_set: yes
       state: present
       reload: yes
-      #FIXME do we still need ?ignoreerrors: yes
   with_items:
       - { name: net.ipv4.conf.all.rp_filter, value: 1 }
       - { name: net.ipv4.conf.default.rp_filter, value: 1 }
   tags:
       - id_3.2.7
-#FIXME Ignore errors enabled due to Container Issue
 - name: "3.2.8 | Ensure TCP SYN Cookies is enabled"
   sysctl:
       name: net.ipv4.tcp_syncookies
@@ -126,7 +117,6 @@
   tags:
       - id_3.2.8
       - no_test
-#FIXME ? Container/Host issue added ignore errors
 - name: "3.3.1 | Ensure IPv6 router advertisements are not accepted"
   sysctl:
       name: '{{ item.name }}'
@@ -140,7 +130,7 @@
   when: rhel7gsa_ipv6_required == true
   tags:
       - id_3.3.1
-#FIXME ? Container/Host issue added ignore errors
+      
 - name: "3.3.2 | Ensure IPv6 redirects are not accepted"
   sysctl:
       name: '{{ item.name }}'

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -125,6 +125,7 @@
       reload: yes
   tags:
       - id_3.2.8
+      - no_test
 #FIXME ? Container/Host issue added ignore errors
 - name: "3.3.1 | Ensure IPv6 router advertisements are not accepted"
   sysctl:

--- a/tasks/section3.yml
+++ b/tasks/section3.yml
@@ -33,7 +33,6 @@
       sysctl_set: yes
       state: present
       reload: yes
-      #ignoreerrors: yes
   with_items:
       - { name: net.ipv4.conf.all.accept_source_route, value: 0 }
       - { name: net.ipv4.conf.default.accept_source_route, value: 0 }
@@ -124,7 +123,6 @@
       value: 1
       state: present
       reload: yes
-      ignoreerrors: yes
   tags:
       - id_3.2.8
 #FIXME ? Container/Host issue added ignore errors
@@ -135,7 +133,6 @@
       sysctl_set: yes
       state: present
       reload: yes
-      ignoreerrors: yes
   with_items:
       - { name: net.ipv6.conf.all.accept_ra, value: 0 }
       - { name: net.ipv6.conf.default.accept_ra, value: 0 }
@@ -150,7 +147,6 @@
       sysctl_set: yes
       state: present
       reload: yes
-      ignoreerrors: yes
   with_items:
       - { name: net.ipv6.conf.all.accept_redirects, value: 0 }
       - { name: net.ipv6.conf.default.accept_redirects, value: 0 }

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -9,7 +9,7 @@
 - name: "4.1.1.1 | Ensure audit log storage size is configured"
   lineinfile:
       dest: /etc/audit/auditd.conf
-      regexp: "^max_log_file"
+      regexp: "max_log_file = *..|max_log_file = 10"
       line: "max_log_file = 10"
       state: present
   when: rhel7gsa_auditd_config == true

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -35,7 +35,7 @@
   when: rhel7gsa_auditd_config == true
   tags:
       - id_4.1.1.3
-#FIXME ignore_errors enabled auditd not fully supported inside containers
+
 - name: "4.1.2 | Ensure auditd service is enabled"
   systemd:
       name: auditd
@@ -45,7 +45,7 @@
   tags:
       - id_4.1.2
       - no_test
-#FIXME ignore_errors enabled auditd not fully supported inside containers
+
 - name: "4.1.3 | Ensure auditing for processes that start prior to auditd is enabled"
   replace:
       dest: /etc/default/grub
@@ -77,7 +77,7 @@
       - id_4.1.16
       - id_4.1.17
       - id_4.1.18
-#FIXME  Container/Host ? issue added ignore errors
+
 - name: "4.2.1.1 Ensure rsyslog Service is enabled"
   systemd:
       name: rsyslog
@@ -87,7 +87,7 @@
   tags:
       - id_4.2.1.1
       - no_test
-#FIXME Container/Host ? issue added ignore errors
+
 - name: "4.2.1.3 | Ensure rsyslog default file permissions configured"
   lineinfile:
       dest: /etc/rsyslog.conf

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -55,6 +55,7 @@
   when: rhel7gsa_auditd_config == true
   tags:
       - id_4.1.3
+      - no_test
 
 - name: "4.1.4-4.1.18 | Configure Auditd rules and configurations."
   template:

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -44,6 +44,7 @@
   when: rhel7gsa_auditd_config == true
   tags:
       - id_4.1.2
+      - no_test
 #FIXME ignore_errors enabled auditd not fully supported inside containers
 - name: "4.1.3 | Ensure auditing for processes that start prior to auditd is enabled"
   replace:

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -41,7 +41,6 @@
       name: auditd
       state: started
       enabled: yes
-  ignore_errors: yes
   when: rhel7gsa_auditd_config == true
   tags:
       - id_4.1.2
@@ -52,7 +51,6 @@
       regexp: '(^GRUB_CMDLINE_LINUX\s*\=\s*)(?:")(.+)(?<!audit=1)(?:")'
       replace: '\1"\2 audit=1"'
       follow: yes
-  ignore_errors: yes
   when: rhel7gsa_auditd_config == true
   tags:
       - id_4.1.3
@@ -83,7 +81,6 @@
       name: rsyslog
       enabled: yes
       state: started
-  ignore_errors: yes
   when: rhel7gsa_logging == "rsyslog" and rhel7gsa_config_logging == true
   tags:
       - id_4.2.1.1
@@ -94,7 +91,6 @@
       regexp: "^\\$FileCreateMode"
       line:  "$FileCreateMode 0640"
       state: present
-  ignore_errors: yes
   when: rhel7gsa_logging == "rsyslog" and rhel7gsa_config_logging == true
   tags:
       - id_4.2.1.3

--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -86,6 +86,7 @@
   when: rhel7gsa_logging == "rsyslog" and rhel7gsa_config_logging == true
   tags:
       - id_4.2.1.1
+      - no_test
 #FIXME Container/Host ? issue added ignore errors
 - name: "4.2.1.3 | Ensure rsyslog default file permissions configured"
   lineinfile:

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -311,7 +311,9 @@
     -  id_5.4.1.4
 
 - name: "5.4.3 | Ensure default group for the root account is GID 0"
-  command: usermod -g 0 root
+  user:
+    name: root
+    group: root
   tags:
       - id_5.4.3
 

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -76,6 +76,8 @@
       owner: root
       group: root
       mode: 0600
+      modification_time: "preserve"
+      access_time: "preserve"
   tags:
       - id_5.1.8
 #Fix Me ? Container/Host issue added ignore errors
@@ -93,6 +95,8 @@
       owner: root
       group: root
       mode: 0600
+      modification_time: "preserve"
+      access_time: "preserve"
   tags:
       - id_5.1.8
 

--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -5,7 +5,7 @@
       enabled: yes
   tags:
       - id_5.1.1
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.2 | Ensure permissions on /etc/crontab are configured"
   file:
       dest: /etc/crontab
@@ -14,7 +14,7 @@
       mode: 0600
   tags:
       - id_5.1.2
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.3 | Ensure permissions on /etc/cron.hourly are configured"
   become: true
   file:
@@ -24,7 +24,7 @@
       mode: 0600
   tags:
       - id_5.1.3
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.4 | Ensure permissions on /etc/cron.daily are configured"
   file:
       dest: /etc/cron.daily
@@ -33,7 +33,7 @@
       mode: 0600
   tags:
       - id_5.1.4
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.5 | Ensure permissions on /etc/cron.weekly are configured"
   file:
       dest: /etc/cron.weekly
@@ -42,7 +42,7 @@
       mode: 0600
   tags:
       - id_5.1.5
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.6 | Ensure permissions on /etc/cron.monthly are configured"
   file:
       dest: /etc/cron.monthly
@@ -51,7 +51,7 @@
       mode: 0600
   tags:
       - id_5.1.6
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.7 | Ensure permissions on /etc/cron.d are configured"
   file:
       dest: /etc/cron.d
@@ -61,14 +61,14 @@
       mode: 0600
   tags:
       - id_5.1.7
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.8 | Ensure at/cron is restricted to authorized users"
   file:
       dest: /etc/at.deny
       state: absent
   tags:
       - id_5.1.8
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.8 | Ensure at/cron is restricted to authorized users"
   file:
       dest: /etc/at.allow
@@ -80,14 +80,14 @@
       access_time: "preserve"
   tags:
       - id_5.1.8
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.8 | Ensure at/cron is restricted to authorized users"
   file:
       dest: /etc/cron.deny
       state: absent
   tags:
       - id_5.1.8
-#Fix Me ? Container/Host issue added ignore errors
+
 - name: "5.1.8 | Ensure at/cron is restricted to authorized users"
   file:
       dest: /etc/cron.allow
@@ -327,7 +327,6 @@
     create=yes
     dest=/etc/bashrc
     line="umask 027"
-  #FIXME is this still needed? ignore_errors: true
   tags:
     - id_5.4.4
 
@@ -337,7 +336,6 @@
     create=yes
     dest=/etc/profile
     line="umask 027"
-  #FIXME is this still needed? ignore_errors: true
   tags:
     - id_5.4.4
 

--- a/tasks/section6.yml
+++ b/tasks/section6.yml
@@ -164,7 +164,6 @@
   register: result6_2_7
   changed_when: "result6_2_7.stdout"
   failed_when: "result6_2_7.stdout"
-  #FIXME is this still required? ignore_errors: yes
   tags:
     - id_6.2.7
 
@@ -189,7 +188,6 @@
   register: result6_2_8
   changed_when: "result6_2_8.stdout"
   failed_when: "result6_2_8.stdout"
-  #FIXME - is this still required? ignore_errors: yes
   tags:
     - id_6.2.8
 


### PR DESCRIPTION
Adds Status Badge to README
Updated README to require ansible 2.7
Removed ignore_errors globally
Added No_Test tags to a few incompatible tasks with containers.

TASK [ansible-os-rhel-7 : 5.4.3 | Ensure default group for the root account is GID 0] ***
task path: /etc/ansible/roles/ansible-os-rhel-7/tasks/section5.yml:313
changed: [127.0.0.1] => {"changed": true, "cmd": ["usermod", "-g", "0", "root"], "delta": "0:00:00.036192", "end": "2019-04-22 19:16:15.582574", "rc": 0, "start": "2019-04-22 19:16:15.546382", "stderr": "usermod: no changes", "stderr_lines": ["usermod: no changes"], "stdout": "", "stdout_lines": []}

--Changed to User Module to make idempotent

TASK [ansible-os-rhel-7 : 5.1.8 | Ensure at/cron is restricted to authorized users] ***
task path: /etc/ansible/roles/ansible-os-rhel-7/tasks/section5.yml:89
changed: [127.0.0.1] => {"changed": true, "dest": "/etc/cron.allow", "gid": 0, "group": "root", "mode": "0600", "owner": "root", "size": 0, "state": "file", "uid": 0}

--Added Preserve Time Parameters to make idempotent

TASK [ansible-os-rhel-7 : 5.1.8 | Ensure at/cron is restricted to authorized users] ***
task path: /etc/ansible/roles/ansible-os-rhel-7/tasks/section5.yml:72
changed: [127.0.0.1] => {"changed": true, "dest": "/etc/at.allow", "gid": 0, "group": "root", "mode": "0600", "owner": "root", "size": 0, "state": "file", "uid": 0}
--Added Preserve Time Paramters to make idempotent

TASK [ansible-os-rhel-7 : 4.1.1.3 | Ensure audit logs are not automatically deleted] ***
task path: /etc/ansible/roles/ansible-os-rhel-7/tasks/section4.yml:29
changed: [127.0.0.1] => {"backup": "", "changed": true, "msg": "line added"}

--Changed Regex to make idempotent

TASK [ansible-os-rhel-7 : 4.1.1.1 | Ensure audit log storage size is configured] ***
task path: /etc/ansible/roles/ansible-os-rhel-7/tasks/section4.yml:9
changed: [127.0.0.1] => {"backup": "", "changed": true, "msg": "line replaced"}

--Resolved when 4.1.1.3 fix was added